### PR TITLE
API authentication is improved

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -15,56 +15,55 @@ $ chmod a+x app.py
 $ ./app.py
 ```
 6. Open a NEW console window (do not close the one where app.py is running).
-  * These processes require authentication with username=berkerol and password=group4
   * GET: Retrive all books
     ```
-    $ curl -u berkerol:group4 -i http://localhost:5000/api/books
+    $ curl -u username:password -i http://localhost:5000/api/books
     ```
   * GET: Retrive all comments
     ```
-    $ curl -u berkerol:group4 -i http://localhost:5000/api/comments
+    $ curl -u username:password -i http://localhost:5000/api/comments
     ```
   * GET: Retrive all users
     ```
-    $ curl -u berkerol:group4 -i http://localhost:5000/api/users
+    $ curl -u username:password -i http://localhost:5000/api/users
     ```
   * GET: Retrive all comments of a book
     ```
-    $ curl -u berkerol:group4 -i http://localhost:5000/api/comments/book/1
+    $ curl -u username:password -i http://localhost:5000/api/comments/book/1
     ```
   * GET: Retrive all comments of a user
     ```
-    $ curl -u berkerol:group4 -i http://localhost:5000/api/comments/user/1
+    $ curl -u username:password -i http://localhost:5000/api/comments/user/1
     ```
   * GET: Retrieve a book
     ```
-    $ curl -u berkerol:group4 -i http://localhost:5000/api/books/2
+    $ curl -u username:password -i http://localhost:5000/api/books/2
     ```
   * GET: Retrieve a comment
     ```
-    $ curl -u berkerol:group4 -i http://localhost:5000/api/comments/2
+    $ curl -u username:password -i http://localhost:5000/api/comments/2
     ```
   * GET: Retrieve a user
     ```
-    $ curl -u berkerol:group4 -i http://localhost:5000/api/users/2
+    $ curl -u username:password -i http://localhost:5000/api/users/2
     ```
   * POST: Create a book
     ```
-    $ curl -u berkerol:group4 -i -H "Content-Type: application/json" -X POST -d '{"name":"1984", "author":"George Orwell", "price":11.0}' http://localhost:5000/api/books
+    $ curl -u username:password -i -H "Content-Type: application/json" -X POST -d '{"name":"1984", "author":"George Orwell", "price":11.0}' http://localhost:5000/api/books
     ```
   * POST: Create a comment
     ```
-    $ curl -u berkerol:group4 -i -H "Content-Type: application/json" -X POST -d '{"book":2, "owner":2, "content":"Wow"}' http://localhost:5000/api/comments
+    $ curl -u username:password -i -H "Content-Type: application/json" -X POST -d '{"book":2, "owner":2, "content":"Wow"}' http://localhost:5000/api/comments
     ```
   * POST: Create a user
     ```
-    $ curl -u berkerol:group4 -i -H "Content-Type: application/json" -X POST -d '{"name":"amerty"}' http://localhost:5000/api/users
+    $ curl -u username:password -i -H "Content-Type: application/json" -X POST -d '{"name":"amerty"}' http://localhost:5000/api/users
     ```
   * PUT: Update a book
     ```
-    $ curl -u berkerol:group4 -i -H "Content-Type: application/json" -X PUT -d '{"price":12.0}' http://localhost:5000/api/books/3
+    $ curl -u username:password -i -H "Content-Type: application/json" -X PUT -d '{"price":12.0}' http://localhost:5000/api/books/3
     ```
   * DELETE: Delete a book
     ```
-    $ curl -u berkerol:group4 -X DELETE http://localhost:5000/api/books/3
+    $ curl -u username:password -X DELETE http://localhost:5000/api/books/3
     ```

--- a/api/app.py
+++ b/api/app.py
@@ -1,4 +1,5 @@
 #!flask/bin/python
+import hashlib
 from flask import Flask, jsonify, abort, make_response, request
 from flask_httpauth import HTTPBasicAuth
 
@@ -45,13 +46,18 @@ comments = [
 users = [
     {
         'id': 1,
-        'name': u'berkerol'
+        'name': u'nicholasramsey'
     },
     {
         'id': 2,
-        'name': u'caglarhizli'
+        'name': u'richardterry'
     }
 ]
+
+admins = {
+    "group4": "33275a8aa48ea918bd53a9181aa975f15ab0d0645398f5918a006d08675c1cb27d5c645dbd084eee56e675e25ba4019f2ecea37ca9e2995b49fcb12c096a032e",
+    "berkerol": "ba3253876aed6bc22d4a6ff53d8406c6ad864195ed144ab5c87621b6c233b548baeae6956df346ec8c17f5ea10f35ee3cbc514797ed7ddd3145464e2a0bab413"
+}
 
 @app.route('/api/books', methods=['GET'])
 @auth.login_required
@@ -178,21 +184,24 @@ def delete_book(book_id):
 
 @app.errorhandler(404)
 def not_found(error):
-    return make_response(jsonify({'error': 'Not found'}), 404)
+    return make_response(jsonify({'error': 'Not Found'}), 404)
 
 @app.errorhandler(400)
-def not_found(error):
+def bad_request(error):
     return make_response(jsonify({'error': 'Bad Request'}), 400)
 
 @auth.get_password
 def get_password(username):
-    if username == 'berkerol':
-        return 'group4'
-    return None
+    if username in admins:
+        return admins[username]
+
+@auth.hash_password
+def hash_password(password):
+    return hashlib.sha512(password.encode()).hexdigest()
 
 @auth.error_handler
 def unauthorized():
-    return make_response(jsonify({'error': 'Unauthorized access'}), 401)
+    return make_response(jsonify({'error': 'Unauthorized Access'}), 401)
 
 if __name__ == '__main__':
     app.run(debug=True, threaded=True)


### PR DESCRIPTION
Changes in #57 are implemented.
`admins` dictionary store usernames and passwords hashed by SHA512.
They are used for authentication not HTTP request methods.
They are not stored explicitly in the repository anymore.
Session control (in #57) is abandoned (username & password are sent with every request as in the past).