### PR TITLE
Test for get_books with unittest

### DIFF
--- a/api/test_api.py
+++ b/api/test_api.py
@@ -1,0 +1,26 @@
+#!flask/bin/python
+import os, sys, subprocess, unittest
+from app import get_books, get_comments
+
+class TestApp(unittest.TestCase):	
+	def test_get_books(self):
+		output = subprocess.check_output(['curl','-u','berkerol:group4','-i','http://localhost:5000/api/books']).replace("\r\n", "\n").partition("{")[2]		
+		self.assertEqual(output,"""
+  "books": [
+    {
+      "author": "Aldous Huxley", 
+      "id": 1, 
+      "name": "Brave New World", 
+      "price": 13.5
+    }, 
+    {
+      "author": "Chuck Palahniuk", 
+      "id": 2, 
+      "name": "Fight Club", 
+      "price": 8.5
+    }
+  ]
+}
+""")
+if __name__=='__main__':
+	unittest.main(exit=False)


### PR DESCRIPTION
This file contains test for get_books.

To run the test, app.py should be working seperately like previously we
did in the api (for further information, look README.md in api folder).

To run the test simply type
"./test-api.py"